### PR TITLE
Added more complete support for findtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ None
 - `fail2ban_ignoreips`: [default: `[127.0.0.1/8]`]: Which IP address/CIDR mask/DNS host should be ignored from fail2ban's actions
 - `fail2ban_bantime`: [default: `600`]: Sets the bantime
 - `fail2ban_maxretry`: [default: `3`]: Maximum number of retries before the host is put into jail
+- `fail2ban_findtime`: [default: `600`]: A host is banned if it has generated `fail2ban_maxretry` during the last `fail2ban_findtime` (can be overriden on a per role basis)
 - `fail2ban_backend`: [default: `auto`]: Specifies the backend used to get files modification
 - `fail2ban_email`: [default: `root@localhost`]: Email address which can be used in the interpolation of the `fail2ban_services`
 - `fail2ban_banaction`: [default: `iptables-multiport`]: Sets the global/default banaction (can be overriden on a per role basis)
@@ -43,6 +44,7 @@ fail2ban_services:
     protocol: tcp                 (optional)
     action: action_               (optional)
     banaction: iptables-multiport (optional)
+    findtime: 600                 (optional)
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ None
 - `fail2ban_ignoreips`: [default: `[127.0.0.1/8]`]: Which IP address/CIDR mask/DNS host should be ignored from fail2ban's actions
 - `fail2ban_bantime`: [default: `600`]: Sets the bantime
 - `fail2ban_maxretry`: [default: `3`]: Maximum number of retries before the host is put into jail
-- `fail2ban_findtime`: [default: `600`]: A host is banned if it has generated `fail2ban_maxretry` during the last `fail2ban_findtime` (can be overriden on a per role basis)
+- `fail2ban_findtime`: [default: `600`]: A host is banned if it has generated `fail2ban_maxretry` during the last `fail2ban_findtime` (this can be overriden for each service)
 - `fail2ban_backend`: [default: `auto`]: Specifies the backend used to get files modification
 - `fail2ban_email`: [default: `root@localhost`]: Email address which can be used in the interpolation of the `fail2ban_services`
 - `fail2ban_banaction`: [default: `iptables-multiport`]: Sets the global/default banaction (can be overriden on a per role basis)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ fail2ban_ignoreips:
  - 127.0.0.1/8
 fail2ban_bantime: 600
 fail2ban_maxretry: 3
+fail2ban_findtime: 600
 fail2ban_backend: auto
 fail2ban_destemail: root@localhost
 fail2ban_banaction: iptables-multiport
@@ -26,3 +27,4 @@ fail2ban_services:
     filter: sshd
     logpath: /var/log/auth.log
     maxretry: 6
+    findtime: 600

--- a/templates/etc/fail2ban/jail.local.j2
+++ b/templates/etc/fail2ban/jail.local.j2
@@ -23,6 +23,7 @@
 ignoreip = {{ fail2ban_ignoreips | join(' ') }}
 bantime  = {{ fail2ban_bantime }}
 maxretry = {{ fail2ban_maxretry }}
+findtime = {{ fail2ban_findtime }}
 
 # "backend" specifies the backend used to get files modification. Available
 # options are "gamin", "polling" and "auto".
@@ -102,6 +103,9 @@ logpath = {{ service.logpath }}
 maxretry = {{ service.maxretry }}
 {% if service.protocol is defined %}
 protocol = {{ service.protocol }}
+{% endif %}
+{% if service.findtime is defined %}
+findtime = {{ service.findtime }}
 {% endif %}
 {% if service.action is defined %}
 action = %({{ service.action }})s

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -4,4 +4,4 @@
   remote_user: vagrant
   sudo: true
   roles:
-    - fail2ban
+    - ansible-fail2ban


### PR DESCRIPTION
I saw there was no option to adjust "findtime" globally, and even though the example for the extra service has the parameter, the actual value is ignored.

My vagrant complained about using the role name "fail2ban", so I prefixed it with "ansible-". Not sure if that's an error though.