### PR TITLE
Parameterize apt's "cache_valid_time" when installing "fail2ban"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     name: fail2ban
     state: latest
     update_cache: true
-    cache_valid_time: 3600
+    cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
   tags: [configuration, fail2ban, fail2ban-install]
 
 - name: update configuration file - /etc/fail2ban/fail2ban.conf


### PR DESCRIPTION
New PR per the feedback in #13.

Thanks!
Dan