### PR TITLE
Add support for per-service bantime

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ fail2ban_services:
     protocol: tcp                 (optional)
     action: action_               (optional)
     banaction: iptables-multiport (optional)
+    bantime: 600                  (optional)
     findtime: 600                 (optional)
 ```
 

--- a/templates/etc/fail2ban/jail.local.j2
+++ b/templates/etc/fail2ban/jail.local.j2
@@ -107,6 +107,9 @@ protocol = {{ service.protocol }}
 {% if service.findtime is defined %}
 findtime = {{ service.findtime }}
 {% endif %}
+{% if service.bantime is defined %}
+bantime = {{ service.bantime }}
+{% endif %}
 {% if service.action is defined %}
 action = %({{ service.action }})s
 {% endif %}


### PR DESCRIPTION
Per [the fail2ban manual][0], jails can define their own bantime to
override the default.  Now specifying a 'bantime' key in
fail2ban_services will add the appropriate entry into the jail.

Fixes Oefenweb/ansible-fail2ban#16.

[0]: http://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Jail_Options