### PR TITLE
make ansible-lint happy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ None
 
 #### Variables
 
+- `fail2ban_install_state`: [default: `latest`]: apt state of fail2ban package (latest, present)
 - `fail2ban_loglevel`: [default: `INFO`]: Sets the loglevel output (CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG)
 - `fail2ban_logtarget`: [default: `/var/log/fail2ban.log`]: Sets the log target. This could be a file, SYSLOG, STDERR or STDOUT
 - `fail2ban_syslog_target`: [default: `/var/log/fail2ban.log`]:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 # defaults file for fail2ban
 ---
+fail2ban_install_state: latest
 fail2ban_loglevel: INFO
 fail2ban_logtarget: /var/log/fail2ban.log
 fail2ban_syslog_target: /var/log/fail2ban.log

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: install
   apt:
     name: "{{ item }}"
-    state: present
+    state: "{{ fail2ban_install_state }}"
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
   with_items: "{{ fail2ban_dependencies }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: install
   apt:
     name: "{{ item }}"
-    state: latest
+    state: present
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
   with_items: "{{ fail2ban_dependencies }}"


### PR DESCRIPTION
use 'present' instead of latest. Re-running the playbook shouldn't update the package.