### PR TITLE
remove default settings (these are duplicates!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,8 @@ None
   roles:
     - fail2ban
   vars:
-  - name: ssh
+  - name: sshd
     port: 2222
-    filter: sshd
-    logpath: /var/log/auth.log
     maxretry: 5
     bantime: -1
 ```


### PR DESCRIPTION
to enable sshd jail, you need to use the `sshd` name ofc