### PR TITLE
[RFR] Replace iteritems to items

### DIFF
--- a/templates/etc/fail2ban/jail.local.j2
+++ b/templates/etc/fail2ban/jail.local.j2
@@ -105,7 +105,7 @@ action = {{ fail2ban_action }}
 {% for service in fail2ban_services %}
 [{{ service.name }}]
 enabled = {{ service.enabled | default(true) | bool | to_json }}
-{% for option, value in service.iteritems() %}
+{% for option, value in service.items() %}
 {% if option not in ['name', 'enabled'] %}
 {{ option }} = {{ value }}
 {% endif %}


### PR DESCRIPTION
With ansible 2.2 and python 3.6 I have this error : 

`"AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"`

This PR fix this.