### PR TITLE
jail.local.j2: sort service.items to ensure idempotency

### DIFF
--- a/templates/etc/fail2ban/jail.local.j2
+++ b/templates/etc/fail2ban/jail.local.j2
@@ -105,7 +105,7 @@ action = {{ fail2ban_action }}
 {% for service in fail2ban_services %}
 [{{ service.name }}]
 enabled = {{ service.enabled | default(true) | bool | to_json }}
-{% for option, value in service.items() %}
+{% for option, value in service.items()|sort %}
 {% if option not in ['name', 'enabled'] %}
 {{ option }} = {{ value }}
 {% endif %}


### PR DESCRIPTION
The promised pull request made in the issue https://github.com/Oefenweb/ansible-fail2ban/issues/48