### PR TITLE
typo in example for sshd

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ None
   vars:
     fail2ban_services:
       # In Ubuntu 16.04 or Debian 9.0 this is sshd
-      - name: ssh
+      - name: sshd
         port: 2222
         maxretry: 5
         bantime: -1


### PR DESCRIPTION
It should be `- name: sshd`, not `ssh`.

Otherwise it fails to start with an error. An entry from `journalctl -xe`:

```
fail2ban-client[]: ERROR  Found no accessible config files for 'filter.d/ssh' under /etc/fail2ban
```