### PR TITLE
Fixed error in Debian 9 distribution facts - Ansible 2.8 update

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # defaults file for fail2ban
 ---
-fail2ban_loglevel: "{{ 'INFO' if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '>=') or ansible_distribution == 'Debian' and ansible_distribution_version is version('9.0', '>=')) else 3 }}"
+fail2ban_loglevel: "{{ 'INFO' if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '>=') or ansible_distribution == 'Debian' and ansible_distribution_version is version('9', '>=')) else 3 }}"
 fail2ban_logtarget: /var/log/fail2ban.log
 fail2ban_syslog_target: /var/log/fail2ban.log
 fail2ban_syslog_facility: 1
@@ -24,4 +24,4 @@ fail2ban_chain: INPUT
 fail2ban_action: '%(action_)s'
 
 fail2ban_services:
-  - name: "{{ 'sshd' if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '>=') or ansible_distribution == 'Debian' and ansible_distribution_version is version('9.0', '>=')) else 'ssh' }}"
+  - name: "{{ 'sshd' if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '>=') or ansible_distribution == 'Debian' and ansible_distribution_version is version('9', '>=')) else 'ssh' }}"


### PR DESCRIPTION
As it was commented [here](https://github.com/Oefenweb/ansible-fail2ban/issues/56), since the update to Ansible 2.8, the role is failing to run on Debian 9.

This is due to [Ansible 2.8 uses a new backend library for the ansible_distribution_* group of facts](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.8.html#distribution-facts)

>  The information returned for the ansible_distribution_* group of facts may have changed slightly. Ansible 2.8 uses a new backend library for information about distributions: nir0s/distro. This library runs on Python-3.8 and fixes many bugs, including correcting release and version names.
The two facts used in playbooks most often, ansible_distribution and ansible_distribution_major_version, should not change. If you discover a change in these facts, please file a bug so we can address the difference. However, other facts like ansible_distribution_release and ansible_distribution_version may change as erroneous information gets corrected.

[Bugfix in WIP status.](https://github.com/ansible/ansible/pull/57814)


This PR solves the error reported by @MarcFinetRtone :
> On my debian stretch, the ansible_distribution_version is 9, not 9.0 nor 9.x. Moreover the version() filter returns False leading to set "ssh" instead of expected "sshd".