### PR TITLE
Allow templating of jails/actions/filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ None
 - `fail2ban_action`: [default: `%(action_)s`]: Default action.  **Note that variables (including the actions defined elsewhere in the config files) must be wrapped in python-style `%(` and `)s` so they are expanded**
 - `fail2ban_sendername`: [default: `Fail2ban`]: The 'from' name for emails sent by mta actions.  NB: Use `fail2ban_sender` to set the 'from' email address.
 - `fail2ban_sender`: [optional]: The 'from' address for emails sent by mta actions.
-- `fail2ban_filterd_path`: [optional]: Path to directory containing filters to copy (**note the trailing slash**)
-- `fail2ban_actiond_path`: [optional]: Path to directory containing actions to copy (**note the trailing slash**)
-- `fail2ban_jaild_path`: [optional]: Path to directory containing jails to copy (**note the trailing slash**)
+- `fail2ban_filters`: [optional]: List of fail2ban filter templates to be templated out to the server. The template files should end with the Jinja2 suffix `.j2` which is automatically removed when sending to the host.
+- `fail2ban_actions`: [optional]: List of fail2ban actions templates to be templated out to the server. The template files should end with the Jinja2 suffix `.j2` which is automatically removed when sending to the host.
+- `fail2ban_jails`: [optional]: List of fail2ban jails templates to be templated out to the server. The template files should end with the Jinja2 suffix `.j2` which is automatically removed when sending to the host.
 
 - `fail2ban_services` [default see `defaults/main.yml`]: Service definitions
 - `fail2ban_services.{n}.name` [required]: Service name (e.g. `ssh`)
@@ -79,7 +79,13 @@ None
   roles:
     - fail2ban
   vars:
-    fail2ban_filterd_path: ../../../files/fail2ban/etc/fail2ban/filter.d/
+    fail2ban_jails:
+      - templates/fail2ban-jails/nginx-http-auth.local.j2
+      - templates/fail2ban-jails/nginx-noproxy.local.j2
+
+    fail2ban_filters:
+      - templates/fail2ban-filters/nginx-noproxy.conf.j2
+
     fail2ban_services:
       - name: apache-wordpress-logins
         port: http,https

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,9 +44,8 @@
     owner: root
     group: root
     mode: 0644
-  with_fileglob:
-    - "{{ fail2ban_filterd_path }}/*.j2"
-  when: fail2ban_filterd_path is defined
+  with_items: "{{ fail2ban_filters }}"
+  when: fail2ban_filters is defined
   notify: restart fail2ban
   tags:
     - configuration
@@ -60,9 +59,8 @@
     owner: root
     group: root
     mode: 0644
-  with_fileglob:
-    - "{{ fail2ban_actiond_path }}/*.j2"
-  when: fail2ban_actiond_path is defined
+  with_items: "{{ fail2ban_actions }}"
+  when: fail2ban_actions is defined
   notify: restart fail2ban
   tags:
     - configuration
@@ -76,9 +74,8 @@
     owner: root
     group: root
     mode: 0644
-  with_fileglob:
-    - "{{ fail2ban_jaild_path }}/*.j2"
-  when: fail2ban_jaild_path is defined
+  with_items: "{{ fail2ban_jails }}"
+  when: fail2ban_jails is defined
   notify: restart fail2ban
   tags:
     - configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,12 +38,14 @@
     - fail2ban-configuration
 
 - name: copy filters
-  copy:
-    src: "{{ fail2ban_filterd_path }}"
-    dest: /etc/fail2ban/filter.d/
+  template:
+    src: "{{ item }}"
+    dest: "/etc/fail2ban/filter.d/{{ item | basename | regex_replace('\\.j2','') }}"
     owner: root
     group: root
     mode: 0644
+  with_fileglob:
+    - "{{ fail2ban_filterd_path }}/*.j2"
   when: fail2ban_filterd_path is defined
   notify: restart fail2ban
   tags:
@@ -52,12 +54,14 @@
     - fail2ban-filters
 
 - name: copy actions
-  copy:
-    src: "{{ fail2ban_actiond_path }}"
-    dest: /etc/fail2ban/action.d/
+  template:
+    src: "{{ item }}"
+    dest: "/etc/fail2ban/action.d/{{ item | basename | regex_replace('\\.j2','') }}"
     owner: root
     group: root
     mode: 0644
+  with_fileglob:
+    - "{{ fail2ban_actiond_path }}/*.j2"
   when: fail2ban_actiond_path is defined
   notify: restart fail2ban
   tags:
@@ -66,12 +70,14 @@
     - fail2ban-actions
 
 - name: copy jails
-  copy:
-    src: "{{ fail2ban_jaild_path }}"
-    dest: /etc/fail2ban/jail.d/
+  template:
+    src: "{{ item }}"
+    dest: "/etc/fail2ban/jail.d/{{ item | basename | regex_replace('\\.j2','') }}"
     owner: root
     group: root
     mode: 0644
+  with_fileglob:
+    - "{{ fail2ban_jaild_path }}/*.j2"
   when: fail2ban_jaild_path is defined
   notify: restart fail2ban
   tags:


### PR DESCRIPTION
This PR allows templating of the jails etc by running the files through the Joinja2 templating engine. By this, local variables can directly be used in a jail, e.g.

```yaml
my_data_dir = "/home/data"
```

in the jail:
```jinja
[myjail]
backend = auto
enabled = true
port = 80,443
protocol = tcp
filter = myfilter
logpath = {{ my_data_dir }}/the.log
````

Furthermore, the new configuration parameters are lists of templates - which means not all jails/filters end up on all target hosts, but the inventory can be used to set specific jails/filters for specific target machines.

This currently breaks backwards compatibility - if this is of concern I can add the old behavior back in addition to the feature here.