### PR TITLE
Allow multiline 'ansible_managed' without breaking fail2ban

### DIFF
--- a/templates/etc/fail2ban/fail2ban.local.j2
+++ b/templates/etc/fail2ban/fail2ban.local.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 # Overrides values from the fail2ban.conf configuration file.
 #

--- a/templates/etc/fail2ban/jail.local.j2
+++ b/templates/etc/fail2ban/jail.local.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 # Fail2Ban local configuration file.
 # Overrides changes in the main jail file, /etc/fail2ban/jail.conf


### PR DESCRIPTION
We use this role in an environment where users used to modify files managed by ansible because they overlooked the single line comment that `{{ ansible_managed }}` inserts by default. As a countermeasure we now use a huge text block spanning several lines to make this more clear.

This commit allows using `{{ ansible_managed }}` even if it spans multiple lines.
