### PR TITLE
Move custom configurations management to dedicated tasksets

### DIFF
--- a/tasks/copy_actions.yml
+++ b/tasks/copy_actions.yml
@@ -1,0 +1,12 @@
+- name: copy actions
+  ansible.builtin.copy:
+    src: "{{ fail2ban_actiond_path }}"
+    dest: /etc/fail2ban/action.d/
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart fail2ban
+  tags:
+    - configuration
+    - fail2ban
+    - fail2ban-actions

--- a/tasks/copy_custom_configurations.yml
+++ b/tasks/copy_custom_configurations.yml
@@ -1,0 +1,11 @@
+- name: copy filters
+  ansible.builtin.import_tasks: copy_filters.yml
+  when: fail2ban_filterd_path is defined
+
+- name: copy actions
+  ansible.builtin.import_tasks: copy_actions.yml
+  when: fail2ban_actiond_path is defined
+
+- name: copy jails
+  ansible.builtin.import_tasks: copy_jails.yml
+  when: fail2ban_jaild_path is defined

--- a/tasks/copy_filters.yml
+++ b/tasks/copy_filters.yml
@@ -1,0 +1,12 @@
+- name: copy filters
+  ansible.builtin.copy:
+    src: "{{ fail2ban_filterd_path }}"
+    dest: /etc/fail2ban/filter.d/
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart fail2ban
+  tags:
+    - configuration
+    - fail2ban
+    - fail2ban-filters

--- a/tasks/copy_jails.yml
+++ b/tasks/copy_jails.yml
@@ -1,0 +1,12 @@
+- name: copy jails
+  ansible.builtin.copy:
+    src: "{{ fail2ban_jaild_path }}"
+    dest: /etc/fail2ban/jail.d/
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart fail2ban
+  tags:
+    - configuration
+    - fail2ban
+    - fail2ban-jails

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,47 +71,8 @@
     - fail2ban-configuration
     - fail2ban-configuration-update
 
-- name: copy filters
-  ansible.builtin.copy:
-    src: "{{ fail2ban_filterd_path }}"
-    dest: /etc/fail2ban/filter.d/
-    owner: root
-    group: root
-    mode: '0644'
-  when: fail2ban_filterd_path is defined
-  notify: restart fail2ban
-  tags:
-    - configuration
-    - fail2ban
-    - fail2ban-filters
-
-- name: copy actions
-  ansible.builtin.copy:
-    src: "{{ fail2ban_actiond_path }}"
-    dest: /etc/fail2ban/action.d/
-    owner: root
-    group: root
-    mode: '0644'
-  when: fail2ban_actiond_path is defined
-  notify: restart fail2ban
-  tags:
-    - configuration
-    - fail2ban
-    - fail2ban-actions
-
-- name: copy jails
-  ansible.builtin.copy:
-    src: "{{ fail2ban_jaild_path }}"
-    dest: /etc/fail2ban/jail.d/
-    owner: root
-    group: root
-    mode: '0644'
-  when: fail2ban_jaild_path is defined
-  notify: restart fail2ban
-  tags:
-    - configuration
-    - fail2ban
-    - fail2ban-jails
+- name: copy custom configurations
+  ansible.builtin.import_tasks: copy_custom_configurations.yml
 
 - name: start and enable service
   ansible.builtin.service:


### PR DESCRIPTION
This allows to use the `tasks_from` parameter of the `import_role` module.
For instance, one could run something like :
```
- name: "Create Traefik fail2ban configuration."
  import_role:
    name: ansible-fail2ban
    tasks_from: copy_custom_configurations
  become: True
  vars:
    fail2ban_filterd_path: "{{ traefik_fail2ban_filterd_path }}"
    fail2ban_actiond_path: "{{ traefik_fail2ban_actiond_path }}"
    fail2ban_jaild_path: "{{ traefik_fail2ban_jaild_path }}"
```
from a Traefik playbook to just add Traefik specific Fail2ban configuration
without reconfiguring everything.