### PR TITLE
Run correctly in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,7 @@
   ansible.builtin.command: >
     fail2ban-server -V
   changed_when: false
+  check_mode: false
   register: _fail2ban_version_raw
   tags:
     - configuration
@@ -25,6 +26,7 @@
   ansible.builtin.set_fact:
     fail2ban_version: "{{ _fail2ban_version_raw.stdout | regex_search('([0-9]+\\.[0-9]+\\.[0-9]+)') }}"
   changed_when: false
+  check_mode: false
   tags:
     - configuration
     - fail2ban


### PR DESCRIPTION
Currently running role in check mode results in error like:
```
TASK [oefenweb.fail2ban : update configuration file - /etc/fail2ban/jail.local]
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleFilterError: Input version value cannot be empty
fatal: [host1]: FAILED! => changed=false 
  msg: 'AnsibleFilterError: Input version value cannot be empty'
```
It's because `fail2ban_version` fact is set in runtime, but `command` module is not executed in check mode by default. Since this task doesn't change configuration it can be always run safely after fail2ban is installed. Disabling `check_mode` on it, will enable users to view configuration difference without applying it(e.g.: `ansible-playbook -C -D site.yml`).