### PR TITLE
Added python3-systemd as a dependency for systemd backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ None
 - `fail2ban_bantime`: [default: `600`]: Sets the bantime
 - `fail2ban_maxretry`: [default: `3`]: Maximum number of retries before the host is put into jail
 - `fail2ban_findtime`: [default: `600`]: A host is banned if it has generated `fail2ban_maxretry` during the last `fail2ban_findtime`
-- `fail2ban_backend`: [default: `auto`]: Specifies the backend used to get files modification
+- `fail2ban_backend`: [default: `auto`]: Specifies the backend used to get files modification. For Debian 12, `systemd` is required.
 - `fail2ban_banaction`: [default: `iptables-multiport`]: Sets the global/default banaction
 - `fail2ban_banaction_allports`: [default: `iptables-allports`]: Sets the global/default banaction for allports
 - `fail2ban_mta`: [default: `sendmail`]: Email action

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,18 @@
     - fail2ban
     - fail2ban-install
 
+- name: Install python3-systemd for systemd backend
+  ansible.builtin.apt:
+    name: python3-systemd
+    state: "{{ apt_install_state | default('latest') }}"
+    update_cache: true
+    cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
+  when: fail2ban_backend == 'systemd'
+  tags:
+    - configuration
+    - fail2ban
+    - fail2ban-install
+
 - name: get fail2ban version
   ansible.builtin.command: >
     fail2ban-server -V


### PR DESCRIPTION
This pull request proposes adding python3-systemd as a dependency in the Fail2Ban configuration when the backend is set to systemd. This addresses an issue on Debian 12 where Fail2Ban fails to function correctly without this dependency.
I encountered this problem while trying to use this role for a Fail2Ban installation on Debian 12. The service was crashing when using systemd as the backend, which I discovered was due to the absence of the python3-systemd package. Without this package, Fail2Ban couldn't connect to the systemd journal, resulting in the service failing to start. I found [this related issue](https://github.com/fail2ban/fail2ban/issues/3292#issuecomment-1678844644) and solution in the Fail2Ban repository, which highlighted this exact problem and its fix.